### PR TITLE
LPS-106935 Distinguish usersGroups from groupId in SearchContext params to fix user site membership assignment

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectUsersDisplayContext.java
@@ -17,6 +17,7 @@ package com.liferay.site.memberships.web.internal.display.context;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -181,9 +182,8 @@ public class SelectUsersDisplayContext {
 			userParams.put(
 				"usersGroups", Long.valueOf(group.getParentGroupId()));
 		}
-		else {
-			userParams.put("usersGroups", getGroupId());
-		}
+
+		userParams.put(Field.GROUP_ID, Long.valueOf(getGroupId()));
 
 		int usersCount = UserLocalServiceUtil.searchCount(
 			themeDisplay.getCompanyId(), searchTerms.getKeywords(),

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5664,7 +5664,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		if (params != null) {
 			attributes.put(
-				Field.GROUP_ID, (Long)params.getOrDefault("usersGroups", 0L));
+				Field.GROUP_ID, (Long)params.getOrDefault(Field.GROUP_ID, 0L));
 		}
 
 		attributes.put("city", city);
@@ -5946,7 +5946,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			else if (!key.equals("usersGroups") && !key.equals("usersOrgs") &&
 					 !key.equals("usersOrgsCount") &&
 					 !key.equals("usersRoles") && !key.equals("usersTeams") &&
-					 !key.equals("usersUserGroups")) {
+					 !key.equals("usersUserGroups") &&
+					 !key.equals(Field.GROUP_ID)) {
 
 				return true;
 			}


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-106935](https://issues.liferay.com/browse/LPS-106935)**

Newly-created users are unable to be assigned to a site via Site > People > Membership.

## Analysis :nerd_face:

When building the `SearchContext`, [LPS-105757](https://issues.liferay.com/browse/LPS-105757) introduced a `usersGroups` key in the `SearchContext`'s `params` to fix [`isGroupAdmin()`](https://github.com/liferay/liferay-portal/blob/9d9fde2b59f8d50feed7ccd01519dbd8edf064a9/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java#L100) checking for a non-existent `groupId` key. However, this resulted in the regression described above.

When [calling `getHits()` using the erroneous `SearchContext`](https://github.com/liferay/liferay-portal/blob/9d9fde2b59f8d50feed7ccd01519dbd8edf064a9/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java#L98), the Memberships page fails to display all of the users that can be added to the site. This happens because [the presence of the `usersGroups` key introduces a must clause into the final query string](https://github.com/liferay/liferay-portal/blob/9d9fde2b59f8d50feed7ccd01519dbd8edf064a9/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserModelPreFilterContributor.java#L95-L114):

```
...{"term":{"groupIds":{"value":"XXXXX"}}}...
```

This clause makes it so that we can only assign users from a pool of users that already belong on the site with the specified `groupId`. But since we are trying to add new users to the site, this clause is the opposite of what we are trying to achieve.

## Solution :tada:

We rename `usersGroups` to `groupId` to distinguish between searching for users with a matching group ID (`usersGroups`) and checking if we are the site admin via `isGroupAdmin()` (`groupId`). We also [add in an additional check for the `groupId` key in `isUseCustomSQL()`](https://github.com/jesseyeh-liferay/liferay-portal/blob/3e79bf22545dfc19201ef227f0cfeab797dbe03d/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java#L5950) to maintain the original logic flow of building the `SearchContext`.