### PR TITLE
LPS-107966

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java
@@ -65,6 +65,8 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 		String fileName = uploadPortletRequest.getFileName(_PARAMETER_NAME);
 		long size = uploadPortletRequest.getSize(_PARAMETER_NAME);
+		String fileDescription = uploadPortletRequest.getParameter(
+			"description");
 
 		_dlValidator.validateFileSize(fileName, size);
 
@@ -84,7 +86,7 @@ public class DLUploadFileEntryHandler implements UploadFileEntryHandler {
 
 			return _dlAppService.addFileEntry(
 				themeDisplay.getScopeGroupId(), folderId, uniqueFileName,
-				contentType, uniqueFileName, StringPool.BLANK, StringPool.BLANK,
+				contentType, uniqueFileName, fileDescription, StringPool.BLANK,
 				inputStream, size, serviceContext);
 		}
 	}

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/java/com/liferay/frontend/image/editor/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -83,6 +83,11 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		template.put("saveEventName", eventName);
 
+		String saveFileDescription = ParamUtil.getString(
+			renderRequest, "saveFileDescription");
+
+		template.put("saveFileDescription", saveFileDescription);
+
 		String saveFileName = ParamUtil.getString(
 			renderRequest, "saveFileName");
 

--- a/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
+++ b/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js
@@ -391,11 +391,13 @@ class ImageEditor extends PortletBase {
 	submitBlob_(imageBlob) {
 		const saveFileName = this.saveFileName;
 		const saveParamName = this.saveParamName;
+		const saveFileDescription = this.saveFileDescription;
 
 		const promise = new Promise((resolve, reject) => {
 			const formData = new FormData();
 
 			formData.append(saveParamName, imageBlob, saveFileName);
+			formData.append('description', saveFileDescription);
 
 			this.fetch(this.saveURL, formData)
 				.then(response => response.json())
@@ -523,6 +525,14 @@ ImageEditor.STATE = {
 	 * @type {String}
 	 */
 	saveEventName: {
+		validator: core.isString
+	},
+
+	/**
+	 * Description of the saved image to send to the server for the save action.
+	 * @type {String}
+	 */
+	saveFileDescription: {
 		validator: core.isString
 	},
 

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/item_selector_preview/js/ItemSelectorPreview.es.js
@@ -89,6 +89,7 @@ const ItemSelectorPreview = ({
 
 	const handleClickEdit = () => {
 		const itemTitle = currentItem.title;
+		const itemDescription = currentItem.description;
 		const editDialogTitle = `${Liferay.Language.get(
 			'edit'
 		)} ${itemTitle} (${Liferay.Language.get('copy')})`;
@@ -117,6 +118,7 @@ const ItemSelectorPreview = ({
 				uri: editItemURL,
 				urlParams: {
 					entityURL: currentItem.url,
+					saveFileDescription: itemDescription,
 					saveFileName: itemTitle,
 					saveParamName: 'imageSelectorFileName',
 					saveURL: uploadItemURL

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -322,6 +322,7 @@ ItemSelectorRepositoryEntryManagementToolbarDisplayContext itemSelectorRepositor
 										data.put("href", themeDisplay.getPathThemeImages() + "/file_system/large/default.png");
 									}
 
+									data.put("description", fileEntry.getDescription());
 									data.put("metadata", itemMedatadaJSONObject.toString());
 									data.put("returnType", ItemSelectorRepositoryEntryBrowserUtil.getItemSelectorReturnTypeClassName(itemSelectorReturnTypeResolver, existingFileEntryReturnType));
 									data.put("title", title);


### PR DESCRIPTION
## Problem :grimacing:

**[LPS-107966](https://issues.liferay.com/browse/LPS-107966)**

In Web Content, when an image is edited and saved, a new image is created containing the edits while the original image is left unchanged. However, the description from the original image is not carried over into the new image.

## Analysis :nerd_face:

Upon [saving the edited image](https://github.com/jesseyeh-liferay/liferay-portal/blob/LPS-107966/modules/apps/frontend-image-editor/frontend-image-editor-web/src/main/resources/META-INF/resources/ImageEditor.es.js#L338-L339), an [upload request is made](https://github.com/jesseyeh-liferay/liferay-portal/blob/LPS-107966/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/upload/DLUploadFileEntryHandler.java#L53) containing a unique filename and MIME type (among other metadata) for the new image. However, metadata from the original image, such as the description, is absent from the request.

## Solution :tada:

We capture the item description of the original image as the `saveFileDescription` at the very moment we go to edit the image. We then forward this data into the `form-data` of the request, which `DLUploadFileEntryHandler` can later retrieve and use when adding a new `FileEntry` for the edited image.