### PR TITLE
LPS-107527

### DIFF
--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
@@ -95,13 +95,12 @@ public class UserSearchTest {
 		PermissionThreadLocal.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(_groupAdminUser));
 
+		String keywords = "";
+		int status = 0;
 		LinkedHashMap<String, Object> userParams =
 			LinkedHashMapBuilder.<String, Object>put(
 				Field.GROUP_ID, Long.valueOf(_groupAdminUser.getGroupIds()[0])
 			).build();
-
-		String keywords = "";
-		int status = 0;
 		int start = 0;
 		int end = 20;
 

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.Hits;
+import com.liferay.portal.kernel.search.Sort;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.users.admin.kernel.util.UsersAdminUtil;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jesse Yeh
+ */
+@RunWith(Arquillian.class)
+public class UserSearchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_groupAdminUser = UserTestUtil.addGroupAdminUser(_group);
+		_groupMemberUser = UserTestUtil.addGroupUser(
+			_group, RoleConstants.SITE_MEMBER);
+
+		_nonGroupMemberUser = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testSearchUsersAsGroupAdmin() throws Exception {
+		Long[] testUserIds = {
+			_groupAdminUser.getUserId(), _groupMemberUser.getUserId(),
+			_nonGroupMemberUser.getUserId()
+		};
+
+		Stream<User> usersStream = _getUsers().stream();
+
+		List<Long> userIds = usersStream.map(
+			User::getUserId
+		).collect(
+			Collectors.toList()
+		);
+
+		Assert.assertTrue(
+			Stream.of(
+				testUserIds
+			).allMatch(
+				userIds::contains
+			));
+	}
+
+	private List<User> _getUsers() throws Exception {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_groupAdminUser));
+
+		LinkedHashMap<String, Object> userParams =
+			LinkedHashMapBuilder.<String, Object>put(
+				Field.GROUP_ID, Long.valueOf(_groupAdminUser.getGroupIds()[0])
+			).build();
+
+		String keywords = "";
+		int status = 0;
+		int start = 0;
+		int end = 20;
+
+		Hits hits = _userLocalService.search(
+			TestPropsValues.getCompanyId(), keywords, status, userParams, start,
+			end, new Sort());
+
+		return UsersAdminUtil.getUsers(hits);
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private User _groupAdminUser;
+
+	@DeleteAfterTestRun
+	private User _groupMemberUser;
+
+	@DeleteAfterTestRun
+	private User _nonGroupMemberUser;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
+++ b/modules/apps/portal-search/portal-search-test/src/testIntegration/java/com/liferay/portal/search/test/UserSearchTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
@@ -101,8 +102,8 @@ public class UserSearchTest {
 			LinkedHashMapBuilder.<String, Object>put(
 				Field.GROUP_ID, Long.valueOf(_groupAdminUser.getGroupIds()[0])
 			).build();
-		int start = 0;
-		int end = 20;
+		int start = QueryUtil.ALL_POS;
+		int end = QueryUtil.ALL_POS;
 
 		Hits hits = _userLocalService.search(
 			TestPropsValues.getCompanyId(), keywords, status, userParams, start,

--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/permission/contributor/UserSearchPermissionFilterContributor.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.users.admin.internal.search.spi.model.permission.contributor;
+
+import com.liferay.portal.kernel.search.BooleanClause;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.search.filter.TermsFilter;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.search.spi.model.permission.SearchPermissionFilterContributor;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Jesse Yeh
+ */
+@Component(
+	immediate = true,
+	property = "indexer.class.name=com.liferay.portal.kernel.model.User",
+	service = SearchPermissionFilterContributor.class
+)
+public class UserSearchPermissionFilterContributor
+	implements SearchPermissionFilterContributor {
+
+	@Override
+	public void contribute(
+		BooleanFilter booleanFilter, long companyId, long[] groupIds,
+		long userId, PermissionChecker permissionChecker, String className) {
+
+		_setTermsFilterField(booleanFilter, Field.ROLE_ID, Field.ROLE_IDS);
+	}
+
+	private void _setTermsFilterField(
+		BooleanFilter booleanFilter, String oldField, String newField) {
+
+		TermsFilter oldTermsFilter;
+		String field;
+
+		for (BooleanClause<Filter> clause :
+				booleanFilter.getShouldBooleanClauses()) {
+
+			if (clause.getClause() instanceof TermsFilter) {
+				oldTermsFilter = (TermsFilter)clause.getClause();
+
+				field = oldTermsFilter.getField();
+
+				if (field.equals(oldField)) {
+					TermsFilter newTermsFilter = new TermsFilter(newField);
+
+					newTermsFilter.addValues(oldTermsFilter.getValues());
+
+					booleanFilter.add(newTermsFilter);
+
+					return;
+				}
+			}
+		}
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/search/Field.java
@@ -135,6 +135,8 @@ public class Field implements Serializable {
 
 	public static final String ROLE_ID = "roleId";
 
+	public static final String ROLE_IDS = "roleIds";
+
 	public static final String ROOT_ENTRY_CLASS_NAME = "rootEntryClassName";
 
 	public static final String ROOT_ENTRY_CLASS_PK = "rootEntryClassPK";


### PR DESCRIPTION
## Problem :grimacing:

This is an update to **[LPS-107527](https://issues.liferay.com/browse/LPS-107527)** that introduces another solution based on the contributor approach from https://github.com/drewbrokke/liferay-portal/pull/970.

## Analysis :nerd_face:

We encounter two issues in the aforementioned pull request:

1. Logic is duplicated in how the [roles](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java#L327-L336) and [group roles](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java#L379-L385) are obtained between the newly-introduced contributor and the `_createSearchPermissionContext()` method in `SearchPermissionCheckerImpl`
1. [There is a redundancy with how the "roleId" and "roleIds" terms are mirrors of each other](https://github.com/drewbrokke/liferay-portal/pull/970#issue-377379813) in the search query. This occurs because [the "roleId" term is the standardized `TermsFilter` field name](https://github.com/jesseyeh-liferay/liferay-portal/blob/LPS-107527-2/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/SearchPermissionCheckerImpl.java#L674-L675), but the actual role IDs of interest are associated with the user's "roleIds" term (see Analysis section in https://github.com/wanderlast/liferay-portal/pull/40).

## Solution :tada:

To avoid duplicating logic, we use the contributor to iterate through all of the search query's filters until we find the one with "roleId" as its field name. We then create a copy of this filter, set its field name to "roleIds," and add it as a new filter. We could instead replace the original filter with the new filter, but neither `BooleanFilter` nor `TermsFilter` support editing/removing terms, seemingly by design. As a result, the second issue outlined above remains unresolved.